### PR TITLE
パラメーターをサーバーから受け取る形に変更

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,6 +8,20 @@
   </head>
   <body>
     <div id="root"></div>
+    <script>
+      // テスト用にサーバーからのデータを模擬
+      window.islandId = 1;
+      window.islandPassword = "hogehoge";
+      window.islandName = "Nepthune島";
+      window.campId = "1";
+      window.viewLastTime = 1727184079;
+      window.campLists = {
+        1: { name: "魏", mark: "∀" },
+        2: { name: "呉", mark: "Ψ" },
+        3: { name: "蜀", mark: "Ж" },
+      };
+      window.islandTurn = 67;
+    </script>
     <script type="module" src="/src/main.jsx"></script>
   </body>
 </html>

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -15,11 +15,13 @@ import { useGetCampBbsTableQuery } from "./redux/rtk_query";
 const selectHAKONIWAData = createSelector(
   (state) => state.HAKONIWAData,
   (HAKONIWAData) => ({
-    islandTurn: HAKONIWAData.islandTurn,
     islandId: HAKONIWAData.islandId,
+    islandPassword: HAKONIWAData.islandPassword,
     islandName: HAKONIWAData.islandName,
     campId: HAKONIWAData.campId,
-    campNameList: HAKONIWAData.campNameList,
+    viewLastTime: HAKONIWAData.viewLastTime,
+    campLists: HAKONIWAData.campLists,
+    islandTurn: HAKONIWAData.islandTurn,
   }),
 );
 const selectNewbbsTable = createSelector(
@@ -144,8 +146,8 @@ function App() {
     }
   }, [data, isSuccess]);
 
-  const { campId, campNameList } = HAKONIWAData;
-  const LBBSTITLE = `${campNameList[campId].mark}${campNameList[campId].name}陣営掲示板`;
+  const { campId, campLists } = HAKONIWAData;
+  const LBBSTITLE = `${campLists[campId].mark}${campLists[campId].name}陣営掲示板`;
 
   return (
     <div className="App">

--- a/src/Message.jsx
+++ b/src/Message.jsx
@@ -7,11 +7,13 @@ import { useUpdateCampBbsTableMutation } from "./redux/rtk_query";
 const selectHAKONIWAData = createSelector(
   (state) => state.HAKONIWAData,
   (HAKONIWAData) => ({
-    islandTurn: HAKONIWAData.islandTurn,
     islandId: HAKONIWAData.islandId,
+    islandPassword: HAKONIWAData.islandPassword,
     islandName: HAKONIWAData.islandName,
     campId: HAKONIWAData.campId,
-    campNameList: HAKONIWAData.campNameList,
+    viewLastTime: HAKONIWAData.viewLastTime,
+    campLists: HAKONIWAData.campLists,
+    islandTurn: HAKONIWAData.islandTurn,
   }),
 );
 
@@ -69,12 +71,12 @@ export function Message({ messageData, indent, toggleModal, modalSetting }) {
 
     if (isDiplomacyMessage) {
       if (writenCampId !== HAKONIWAData.campId) {
-        let { name, mark } = HAKONIWAData.campNameList[writenCampId];
+        let { name, mark } = HAKONIWAData.campLists[writenCampId];
         diplomacyCampName = `${mark}${name}から【外交文書】が届いています。`;
       } else {
         let targetCampName = [];
         targetCampIds.forEach((id) => {
-          let { name, mark } = HAKONIWAData.campNameList[id];
+          let { name, mark } = HAKONIWAData.campLists[id];
           targetCampName.push(`${mark}${name}`);
         });
         diplomacyCampName =

--- a/src/redux/HAKONIWADataSlice.js
+++ b/src/redux/HAKONIWADataSlice.js
@@ -3,15 +3,13 @@ import { createSlice } from "@reduxjs/toolkit";
 export const HAKONIWADataSlice = createSlice({
   name: "HAKONIWAData",
   initialState: {
-    islandTurn: 9,
-    islandId: 1,
-    islandName: "Nepthune島",
-    campId: "1",
-    campNameList: {
-      1: { name: "魏", mark: "∀" },
-      2: { name: "呉", mark: "Ψ" },
-      3: { name: "蜀", mark: "Ж" },
-    },
+    islandId: window.islandId,
+    islandPassword: window.islandPassword,
+    islandName: window.islandName,
+    campId: window.campId,
+    viewLastTime: window.viewLastTime,
+    campLists: window.campLists,
+    islandTurn: window.islandTurn,
   },
   setParam: (state, action) => {
     state.islandId = action.payload.islandId;


### PR DESCRIPTION
#9 
appohbbsだとHTTP_REFERERとか使って遷移元のページチェックをしたあとに掲示板を表示をしている。
この掲示板もそのチェックしてからperlの中で作ったindex.htmlを読み込んでprintする想定のため、perlから箱庭のパラメータを変数として渡す。
例:`window.islandTurn = $HislandTurn;`

正直他の対応方法がある気はしているが、実装が流用出来て楽なので、言語そのものを変える時に検討する。したい。すべき。