### PR TITLE
読込中の処理見直し、アニメーション追加

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -36,49 +36,29 @@ html {
 }
 
 .RELOAD {
-    display: inline-block;
-    vertical-align: middle;
-    color: #333;
-    line-height: 1;
     position: relative;
-    width: 1em;
-    height: 1em;
-    transform: rotate(45deg);
-}
-
-.RELOAD::before {
-    content: "";
-    position: absolute;
-    top: 0;
-    left: 0;
-    width: inherit;
-    height: inherit;
-    border: 0.1em solid currentColor;
+    border: 0.3em solid;
     border-right-color: transparent;
-    border-radius: 50%;
+    border-radius: 100%;
     box-sizing: border-box;
-    transform: rotate(-45deg);
 }
 
-.RELOAD::after {
-    content: "";
+.RELOAD:before {
     position: absolute;
-    top: 0.05em;
-    right: 50%;
-    width: 0.2em;
-    height: 0.2em;
-    border: 0.1em solid currentColor;
-    border-left: 0;
-    border-bottom: 0;
-    box-sizing: content-box;
-    transform: translateX(0.14142em) rotate(45deg);
-    transform-origin: top right;
+    top: 0.4em;
+    right: -0.5em;
+    content: "";
+    height: 50%;
+    border: 0.6em solid transparent;
+    border-top: 0.6em solid;
+    background: transparent;
+    transform-origin: left top;
+    transform: rotate(-45deg);
+    box-sizing: border-box;
 }
 
 .LOADING-CIRCLE {
-    width: 32px;
-    height: 32px;
-    margin: 20px auto;
+    margin: auto;
     border: 4px rgba(0, 0, 0, 0.25) solid;
     border-top: 4px black solid;
     border-radius: 50%;

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -5,8 +5,9 @@ import BbsMessages from "./BbsMessages.jsx";
 import FixedFooterButtons from "./FixedFooterButtons.jsx";
 import ModalWindow from "./ModalWindow";
 import Toast from "./Toast";
-import { useSelector } from "react-redux";
+import { useSelector, useDispatch } from "react-redux";
 import { useUpdateCampBbsTableMutation } from "./redux/rtk_query";
+import { setLoadingState } from "./redux/loadingStateSlice.js";
 import { createSelector } from "reselect";
 import { message_newPost, message_edit, message_pin, message_delete } from "./postManager.js";
 
@@ -24,11 +25,11 @@ const selectHAKONIWAData = createSelector(
 );
 
 function App() {
-    // const [messageField, setMessageField] = useState();
     const HAKONIWAData = useSelector(selectHAKONIWAData);
     const { HcampId, HcampLists } = useSelector(selectHAKONIWAData);
     const isModalOpen = useSelector((state) => state.modalWindow.viewType !== "close");
     const [updateCampBbsTable] = useUpdateCampBbsTableMutation();
+    const dispatch = useDispatch();
 
     const messageSend = (form, formType) => {
         let updateType = formType;
@@ -54,7 +55,7 @@ function App() {
             return false;
         }
 
-        // setIsButtonDisabled(true);
+        dispatch(setLoadingState(true));
 
         const formData = new FormData();
         formData.append("newMessage", JSON.stringify(createMessage));

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -5,9 +5,8 @@ import BbsMessages from "./BbsMessages.jsx";
 import FixedFooterButtons from "./FixedFooterButtons.jsx";
 import ModalWindow from "./ModalWindow";
 import Toast from "./Toast";
-import { useSelector, useDispatch } from "react-redux";
+import { useSelector } from "react-redux";
 import { useUpdateCampBbsTableMutation } from "./redux/rtk_query";
-import { setLoadingState } from "./redux/loadingStateSlice.js";
 import { createSelector } from "reselect";
 import { message_newPost, message_edit, message_pin, message_delete } from "./postManager.js";
 
@@ -29,7 +28,6 @@ function App() {
     const { HcampId, HcampLists } = useSelector(selectHAKONIWAData);
     const isModalOpen = useSelector((state) => state.modalWindow.viewType !== "close");
     const [updateCampBbsTable] = useUpdateCampBbsTableMutation();
-    const dispatch = useDispatch();
 
     const messageSend = (form, formType) => {
         let updateType = formType;
@@ -54,8 +52,6 @@ function App() {
         if (!createMessage) {
             return false;
         }
-
-        dispatch(setLoadingState(true));
 
         const formData = new FormData();
         formData.append("newMessage", JSON.stringify(createMessage));

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,15 +1,12 @@
-import React, { useState, useEffect } from "react";
+import React from "react";
 import "./App.css";
 import "./index.css";
 import BbsMessages from "./BbsMessages.jsx";
 import FixedFooterButtons from "./FixedFooterButtons.jsx";
 import ModalWindow from "./ModalWindow";
 import Toast from "./Toast";
-import { useSelector, useDispatch } from "react-redux";
-import { update } from "./redux/bbsTableSlice";
-import { modalToggle } from "./redux/modalWindowSlice";
-import { formReset } from "./redux/formTypeParamSlice";
-import { useGetCampBbsTableQuery, useUpdateCampBbsTableMutation } from "./redux/rtk_query";
+import { useSelector } from "react-redux";
+import { useUpdateCampBbsTableMutation } from "./redux/rtk_query";
 import { createSelector } from "reselect";
 import { message_newPost, message_edit, message_pin, message_delete } from "./postManager.js";
 
@@ -27,22 +24,13 @@ const selectHAKONIWAData = createSelector(
 );
 
 function App() {
-    const [messageField, setMessageField] = useState(<div className="LOADING-CIRCLE"></div>);
+    // const [messageField, setMessageField] = useState();
     const HAKONIWAData = useSelector(selectHAKONIWAData);
     const { HcampId, HcampLists } = useSelector(selectHAKONIWAData);
     const isModalOpen = useSelector((state) => state.modalWindow.viewType !== "close");
-    const dispatch = useDispatch();
-    const { data, isSuccess, refetch } = useGetCampBbsTableQuery(HcampId);
     const [updateCampBbsTable] = useUpdateCampBbsTableMutation();
 
-    const bbsTable_reload = () => {
-        refetch();
-        if (isSuccess) {
-            dispatch(update({ newdata: data }));
-        }
-    };
-
-    const messageSend = async (form, formType) => {
+    const messageSend = (form, formType) => {
         let updateType = formType;
         if (updateType === "diplomacy") updateType = "new"; // 外交文書はnewと同じ扱い
         let createMessage;
@@ -66,47 +54,35 @@ function App() {
             return false;
         }
 
+        // setIsButtonDisabled(true);
+
         const formData = new FormData();
-        for (let i = 0; i < createMessage.images.length; i++) {
-            formData.append("images", createMessage.images[i]);
-        }
-        createMessage.images = [];
         formData.append("newMessage", JSON.stringify(createMessage));
+        if (createMessage.images) {
+            for (let i = 0; i < createMessage.images.length; i++) {
+                formData.append("images", createMessage.images[i]);
+            }
+            createMessage.images = [];
+        }
 
         // API通信
-        const result = await updateCampBbsTable({
+        updateCampBbsTable({
             campId: HcampId,
             subMethod: updateType,
             formData,
             formType,
         });
-        const { data } = result;
-
-        dispatch(update({ newdata: data })); // データを更新
-
-        if (!(formType === "pin" || formType === "delete")) {
-            console.log(formType);
-            dispatch(formReset({ formType })); // フォームの保持状態をリセット
-            dispatch(modalToggle({ modalType: "close", contentParam: "" })); // モーダルウィンドウを閉じる
-        }
 
         return false;
     };
-
-    useEffect(() => {
-        if (isSuccess) {
-            dispatch(update({ newdata: data }));
-            setMessageField(<BbsMessages messageSend={messageSend} />);
-        }
-    }, [data, isSuccess, dispatch]);
 
     const LBBSTITLE = `${HcampLists[HcampId].mark}${HcampLists[HcampId].name}陣営掲示板`;
 
     return (
         <div className="App">
             <h1 className="mb-8 text-2xl font-bold">{LBBSTITLE}</h1>
-            {messageField}
-            <FixedFooterButtons bbsTable_reload={bbsTable_reload} />
+            <BbsMessages messageSend={messageSend} />
+            <FixedFooterButtons />
             {isModalOpen && <ModalWindow messageSend={messageSend} />}
             <Toast />
         </div>

--- a/src/BbsMessages.jsx
+++ b/src/BbsMessages.jsx
@@ -1,7 +1,9 @@
 import React from "react";
+import "./App.css";
 import { useSelector } from "react-redux";
 import Message from "./Message";
 import { createSelector } from "reselect";
+import { useGetCampBbsTableQuery } from "./redux/rtk_query";
 
 const selectNewbbsTable = createSelector(
     (state) => state.bbsTable,
@@ -13,9 +15,33 @@ const selectNewbbsTable = createSelector(
 
 export default function BbsMessages({ messageSend }) {
     const newbbsTable = useSelector(selectNewbbsTable);
-    if (!newbbsTable.log) {
-        return null;
+    const HcampId = useSelector((state) => state.HAKONIWAData.campId);
+    const { error, isLoading } = useGetCampBbsTableQuery(HcampId);
+
+    if (isLoading) {
+        return <div className="LOADING-CIRCLE h-10 w-10"></div>;
     }
+
+    if (error) {
+        return (
+            <div>
+                エラーが発生しました。
+                <br />
+                再度読み込み直してください。
+            </div>
+        );
+    }
+
+    if (newbbsTable.log.length === 0) {
+        return (
+            <div>
+                まだメッセージがありません。
+                <br />
+                新規投稿ボタンからメッセージを投稿しましょう！
+            </div>
+        );
+    }
+
     let MessageArray = [];
 
     const renderMessage = (messageData, depth, isFixed) => (

--- a/src/FixedFooterButtons.jsx
+++ b/src/FixedFooterButtons.jsx
@@ -19,7 +19,7 @@ export default function FixedFooterButtons() {
                     onClick={() => refetch()}
                     disabled={isLoadingState}
                 >
-                    <span className="RELOAD text-3xl"></span>
+                    <span className={`block h-8 w-8 ${isLoadingState ? "LOADING-CIRCLE" : "RELOAD"}`}></span>
                 </button>
             </div>
             <div className="fixed bottom-4 right-4 mb-2">

--- a/src/FixedFooterButtons.jsx
+++ b/src/FixedFooterButtons.jsx
@@ -2,7 +2,6 @@ import React from "react";
 import { useDispatch, useSelector } from "react-redux";
 import { useGetCampBbsTableQuery } from "./redux/rtk_query";
 import { modalToggle } from "./redux/modalWindowSlice";
-import { setLoadingState } from "./redux/loadingStateSlice";
 
 export default function FixedFooterButtons() {
     const dispatch = useDispatch();
@@ -12,17 +11,12 @@ export default function FixedFooterButtons() {
 
     const buttonClass_anime = "transition duration-100 hover:brightness-110 active:brightness-75 active:scale-95";
 
-    const handleReload = () => {
-        dispatch(setLoadingState(true));
-        refetch();
-    };
-
     return (
         <>
             <div className="fixed bottom-4 left-4">
                 <button
                     className={`mb-3 rounded-full border bg-white p-4 shadow-md ${!isLoadingState ? buttonClass_anime : "brightness-75"}`}
-                    onClick={handleReload}
+                    onClick={() => refetch()}
                     disabled={isLoadingState}
                 >
                     <span className="RELOAD text-3xl"></span>

--- a/src/FixedFooterButtons.jsx
+++ b/src/FixedFooterButtons.jsx
@@ -1,34 +1,45 @@
 import React from "react";
-import { useDispatch } from "react-redux";
+import { useDispatch, useSelector } from "react-redux";
 import { useGetCampBbsTableQuery } from "./redux/rtk_query";
 import { modalToggle } from "./redux/modalWindowSlice";
+import { setLoadingState } from "./redux/loadingStateSlice";
 
 export default function FixedFooterButtons() {
     const dispatch = useDispatch();
-    const { refetch } = useGetCampBbsTableQuery("1");
+    const HcampId = useSelector((state) => state.HAKONIWAData.campId);
+    const { refetch } = useGetCampBbsTableQuery(HcampId);
+    const isLoadingState = useSelector((state) => state.loadingState.isLoadingState);
 
     const buttonClass_anime =
         "transition duration-100 hover:brightness-125 hover:scale-105 active:brightness-75 active:scale-95";
+
+    const handleReload = () => {
+        dispatch(setLoadingState(true));
+        refetch();
+    };
 
     return (
         <>
             <div className="fixed bottom-4 left-4">
                 <button
-                    className={`mb-3 rounded-full border bg-white p-4 shadow-md ${buttonClass_anime}`}
-                    onClick={() => refetch()}
+                    className={`mb-3 rounded-full border bg-white p-4 shadow-md ${!isLoadingState ? buttonClass_anime : "brightness-75"}`}
+                    onClick={handleReload}
+                    disabled={isLoadingState}
                 >
                     <span className="RELOAD text-3xl"></span>
                 </button>
             </div>
             <div className="fixed bottom-4 right-4 mb-2">
                 <button
-                    className={`m-2 rounded border-none bg-blue-600 p-5 font-bold text-white shadow-md ${buttonClass_anime}`}
+                    className={`m-2 rounded border-none bg-blue-600 p-5 font-bold text-white shadow-md ${!isLoadingState ? buttonClass_anime : "brightness-75"}`}
+                    disabled={isLoadingState}
                     onClick={() => dispatch(modalToggle({ modalType: "new", contentParam: "0" }))}
                 >
                     新規投稿
                 </button>
                 <button
-                    className={`m-2 rounded border-none bg-blue-600 p-5 font-bold text-white shadow-md ${buttonClass_anime}`}
+                    className={`m-2 rounded border-none bg-blue-600 p-5 font-bold text-white shadow-md ${!isLoadingState ? buttonClass_anime : "brightness-75"}`}
+                    disabled={isLoadingState}
                     onClick={() =>
                         dispatch(
                             modalToggle({

--- a/src/FixedFooterButtons.jsx
+++ b/src/FixedFooterButtons.jsx
@@ -1,9 +1,12 @@
 import React from "react";
 import { useDispatch } from "react-redux";
+import { useGetCampBbsTableQuery } from "./redux/rtk_query";
 import { modalToggle } from "./redux/modalWindowSlice";
 
-export default function FixedFooterButtons({ bbsTable_reload }) {
+export default function FixedFooterButtons() {
     const dispatch = useDispatch();
+    const { refetch } = useGetCampBbsTableQuery("1");
+
     const buttonClass_anime =
         "transition duration-100 hover:brightness-125 hover:scale-105 active:brightness-75 active:scale-95";
 
@@ -12,7 +15,7 @@ export default function FixedFooterButtons({ bbsTable_reload }) {
             <div className="fixed bottom-4 left-4">
                 <button
                     className={`mb-3 rounded-full border bg-white p-4 shadow-md ${buttonClass_anime}`}
-                    onClick={bbsTable_reload}
+                    onClick={() => refetch()}
                 >
                     <span className="RELOAD text-3xl"></span>
                 </button>

--- a/src/FixedFooterButtons.jsx
+++ b/src/FixedFooterButtons.jsx
@@ -10,8 +10,7 @@ export default function FixedFooterButtons() {
     const { refetch } = useGetCampBbsTableQuery(HcampId);
     const isLoadingState = useSelector((state) => state.loadingState.isLoadingState);
 
-    const buttonClass_anime =
-        "transition duration-100 hover:brightness-125 hover:scale-105 active:brightness-75 active:scale-95";
+    const buttonClass_anime = "transition duration-100 hover:brightness-110 active:brightness-75 active:scale-95";
 
     const handleReload = () => {
         dispatch(setLoadingState(true));

--- a/src/Message.jsx
+++ b/src/Message.jsx
@@ -37,8 +37,7 @@ export default function Message({ messageData, indent, isFixed, messageSend }) {
     const isLoadingState = useSelector((state) => state.loadingState.isLoadingState);
 
     const dispatch = useDispatch();
-    const buttonClass_anime =
-        "transition duration-100 hover:brightness-125 hover:scale-105 active:brightness-75 active:scale-95";
+    const buttonClass_anime = "transition duration-100 hover:brightness-110 active:brightness-75 active:scale-95";
 
     const isDeletedMessage = HwritenTurn === -1;
     const isOwnMessage = islandId === HislandId;

--- a/src/Message.jsx
+++ b/src/Message.jsx
@@ -34,6 +34,7 @@ export default function Message({ messageData, indent, isFixed, messageSend }) {
         writenTurn,
         important,
     } = messageData;
+    const isLoadingState = useSelector((state) => state.loadingState.isLoadingState);
 
     const dispatch = useDispatch();
     const buttonClass_anime =
@@ -129,7 +130,8 @@ export default function Message({ messageData, indent, isFixed, messageSend }) {
                 <div className="m-0.5 flex items-end pb-1">
                     {!isFixed && (
                         <button
-                            className={`m-0.5 ml-1 whitespace-nowrap rounded border bg-blue-600 p-1.5 text-white ${buttonClass_anime}`}
+                            className={`m-0.5 ml-1 whitespace-nowrap rounded border bg-blue-600 p-1.5 text-white ${!isLoadingState ? buttonClass_anime : "brightness-75"}`}
+                            disabled={isLoadingState}
                             onClick={() => {
                                 dispatch(
                                     formInitial({
@@ -151,7 +153,8 @@ export default function Message({ messageData, indent, isFixed, messageSend }) {
                     {isOwnMessage && !isDiplomacyMessage && (
                         <>
                             <button
-                                className={`m-0.5 ml-1 whitespace-nowrap rounded border bg-green-600 p-1.5 text-white ${buttonClass_anime}`}
+                                className={`m-0.5 ml-1 whitespace-nowrap rounded border bg-green-600 p-1.5 text-white ${!isLoadingState ? buttonClass_anime : "brightness-75"}`}
+                                disabled={isLoadingState}
                                 onClick={() => {
                                     dispatch(
                                         formInitial({
@@ -171,7 +174,8 @@ export default function Message({ messageData, indent, isFixed, messageSend }) {
                                 編集
                             </button>
                             <button
-                                className={`m-0.5 ml-1 whitespace-nowrap rounded border bg-red-600 p-1.5 text-white ${buttonClass_anime}`}
+                                className={`m-0.5 ml-1 whitespace-nowrap rounded border bg-red-600 p-1.5 text-white ${!isLoadingState ? buttonClass_anime : "brightness-75"}`}
+                                disabled={isLoadingState}
                                 onClick={() => messageSend(messageData, "delete")}
                             >
                                 削除
@@ -179,7 +183,8 @@ export default function Message({ messageData, indent, isFixed, messageSend }) {
                         </>
                     )}
                     <button
-                        className={`m-0.5 whitespace-nowrap rounded-full border border-dashed border-slate-500 bg-white p-1.5 ${buttonClass_anime}`}
+                        className={`m-0.5 whitespace-nowrap rounded-full border border-dashed border-slate-500 bg-white p-1.5 ${!isLoadingState ? buttonClass_anime : "brightness-75"}`}
+                        disabled={isLoadingState}
                         onClick={() => messageSend(messageData, "pin")}
                     >
                         {isImportant && "解除"}

--- a/src/ModalWindow.jsx
+++ b/src/ModalWindow.jsx
@@ -20,8 +20,7 @@ export default function ModalWindow({ messageSend }) {
     const ModalContentParam = useSelector((state) => state.modalWindow.contentParam);
     const [modalContent, setModalContent] = useState();
     const [isOpen_animeClass, setIsOpen_animeClass] = useState(false);
-    const buttonClass_anime =
-        "transition duration-100 hover:brightness-125 hover:scale-105 active:brightness-75 active:scale-95";
+    const buttonClass_anime = "transition duration-100 hover:brightness-110 active:brightness-75 active:scale-95";
 
     useEffect(() => {
         setModalContent(getModalContent());
@@ -123,7 +122,7 @@ function PostForm({ formType, MessageNo, messageSend }) {
                     <div className="ml-auto mt-auto">
                         <button
                             type="submit"
-                            className={`m-2 rounded border-none bg-blue-600 px-8 py-4 text-xl font-bold text-white transition duration-100 ${isSubmitDisabled || isLoadingState ? "brightness-50" : "hover:scale-105 hover:brightness-125 active:scale-95 active:brightness-75"}`}
+                            className={`m-2 rounded border-none bg-blue-600 px-8 py-4 text-xl font-bold text-white transition duration-100 ${isSubmitDisabled || isLoadingState ? "brightness-50" : "hover:brightness-110 active:scale-95 active:brightness-75"}`}
                             disabled={isSubmitDisabled || isLoadingState}
                         >
                             {formButtonName(formType)}

--- a/src/ModalWindow.jsx
+++ b/src/ModalWindow.jsx
@@ -61,6 +61,7 @@ function PostForm({ formType, MessageNo, messageSend }) {
     const [isSubmitDisabled, setIsSubmitDisabled] = useState(true);
     const formData = useSelector(SelectSaveform);
     const dispatch = useDispatch();
+    const isLoadingState = useSelector((state) => state.loadingState.isLoadingState);
 
     useEffect(() => {
         setIsSubmitDisabled(!formData[formType].content);
@@ -122,8 +123,8 @@ function PostForm({ formType, MessageNo, messageSend }) {
                     <div className="ml-auto mt-auto">
                         <button
                             type="submit"
-                            className={`m-2 rounded border-none bg-blue-600 px-8 py-4 text-xl font-bold text-white transition duration-100 ${isSubmitDisabled ? "brightness-50" : "hover:scale-105 hover:brightness-125 active:scale-95 active:brightness-75"}`}
-                            disabled={isSubmitDisabled}
+                            className={`m-2 rounded border-none bg-blue-600 px-8 py-4 text-xl font-bold text-white transition duration-100 ${isSubmitDisabled || isLoadingState ? "brightness-50" : "hover:scale-105 hover:brightness-125 active:scale-95 active:brightness-75"}`}
+                            disabled={isSubmitDisabled || isLoadingState}
                         >
                             {formButtonName(formType)}
                         </button>

--- a/src/index.css
+++ b/src/index.css
@@ -1,7 +1,7 @@
+@import url("//fonts.googleapis.com/css?family=Noto+Sans+JP:400,700&display=swap&subset=japanese");
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
-@import url("//fonts.googleapis.com/css?family=Noto+Sans+JP:400,700&display=swap&subset=japanese");
 
 * {
     font-family: "Noto Sans JP", sans-serif;

--- a/src/redux/formTypeParamSlice.js
+++ b/src/redux/formTypeParamSlice.js
@@ -40,8 +40,11 @@ const save = (state, { formType, formName, formValue }) => {
 };
 
 const reset = (state, { formType }) => {
-    state[formType].title = "";
-    state[formType].content = "";
+    if (formType !== undefined) {
+        // getリクエストはformTypeがundefined
+        state[formType].title = "";
+        state[formType].content = "";
+    }
 };
 
 export const formTypeParamSlice = createSlice({

--- a/src/redux/loadingStateSlice.js
+++ b/src/redux/loadingStateSlice.js
@@ -1,0 +1,16 @@
+import { createSlice } from "@reduxjs/toolkit";
+
+const loadingStateSlice = createSlice({
+    name: "loadingState",
+    initialState: {
+        isLoadingState: false,
+    },
+    reducers: {
+        setLoadingState: (state, action) => {
+            state.isLoadingState = action.payload;
+        },
+    },
+});
+
+export const { setLoadingState } = loadingStateSlice.actions;
+export default loadingStateSlice.reducer;

--- a/src/redux/rtk_query.js
+++ b/src/redux/rtk_query.js
@@ -3,6 +3,7 @@ import { update } from "./bbsTableSlice";
 import { modalToggle } from "./modalWindowSlice";
 import { formReset } from "./formTypeParamSlice";
 import { showToast } from "./toastSlice";
+import { setLoadingState } from "./loadingStateSlice";
 
 const baseHeaders = (headers) => {
     headers.set("Access-Control-Request-Headers", "origin, x-requested-with");
@@ -19,6 +20,7 @@ const baseQuery = fetchBaseQuery({
 const baseQueryWithReauth = async (args, api, body) => {
     let result = await baseQuery(args, api, body);
     const { formType } = args;
+    api.dispatch(setLoadingState(false)); // ボタン制御を解除
     if (result.error) {
         api.dispatch(showToast({ description: `エラーが発生しました`, success: false }));
     } else {

--- a/src/redux/rtk_query.js
+++ b/src/redux/rtk_query.js
@@ -18,6 +18,7 @@ const baseQuery = fetchBaseQuery({
 });
 
 const baseQueryWithReauth = async (args, api, body) => {
+    api.dispatch(setLoadingState(true)); // ボタン制御
     let result = await baseQuery(args, api, body);
     const { formType } = args;
     api.dispatch(setLoadingState(false)); // ボタン制御を解除

--- a/src/redux/rtk_query.js
+++ b/src/redux/rtk_query.js
@@ -18,9 +18,9 @@ const baseQuery = fetchBaseQuery({
 });
 
 const baseQueryWithReauth = async (args, api, body) => {
+    const { formType } = args;
     api.dispatch(setLoadingState(true)); // ボタン制御
     let result = await baseQuery(args, api, body);
-    const { formType } = args;
     api.dispatch(setLoadingState(false)); // ボタン制御を解除
     if (result.error) {
         api.dispatch(showToast({ description: `エラーが発生しました`, success: false }));

--- a/src/redux/rtk_query.js
+++ b/src/redux/rtk_query.js
@@ -1,5 +1,8 @@
 import { createApi, fetchBaseQuery } from "@reduxjs/toolkit/query/react";
-import { showToast } from "./toastSlice"; // トーストメッセージを表示するためのアクション
+import { update } from "./bbsTableSlice";
+import { modalToggle } from "./modalWindowSlice";
+import { formReset } from "./formTypeParamSlice";
+import { showToast } from "./toastSlice";
 
 const baseHeaders = (headers) => {
     headers.set("Access-Control-Request-Headers", "origin, x-requested-with");
@@ -15,12 +18,14 @@ const baseQuery = fetchBaseQuery({
 
 const baseQueryWithReauth = async (args, api, body) => {
     let result = await baseQuery(args, api, body);
-    const message = successMessage(args.formType);
+    const { formType } = args;
     if (result.error) {
-        // エラーが発生した場合の処理
         api.dispatch(showToast({ description: `エラーが発生しました`, success: false }));
     } else {
-        api.dispatch(showToast({ description: message, success: true }));
+        api.dispatch(showToast({ description: successMessage(formType), success: true }));
+        api.dispatch(update({ newdata: result.data })); // データを更新
+        api.dispatch(formReset({ formType })); // フォームの保持状態をリセット
+        api.dispatch(modalToggle({ modalType: "close", contentParam: "" })); // モーダルウィンドウを閉じる
     }
     return result;
 };

--- a/src/redux/store.js
+++ b/src/redux/store.js
@@ -4,6 +4,7 @@ import HAKONIWADataReducer from "./HAKONIWADataSlice";
 import toastReducer from "./toastSlice";
 import formTypeParamReducer from "./formTypeParamSlice";
 import modalWindowReducer from "./modalWindowSlice";
+import loadingStateReducer from "./loadingStateSlice";
 import { campApi } from "./rtk_query";
 
 export const store = configureStore({
@@ -13,6 +14,7 @@ export const store = configureStore({
         toast: toastReducer,
         formTypeParam: formTypeParamReducer,
         modalWindow: modalWindowReducer,
+        loadingState: loadingStateReducer,
         [campApi.reducerPath]: campApi.reducer,
     },
     middleware: (getDefaultMiddleware) => getDefaultMiddleware().concat(campApi.middleware),


### PR DESCRIPTION
#7
API通信中かの状態をRedux側で持って、状態切替えはrtk_query側でやるように変更。
通信中はAPI通信が出来る導線があるボタンを全てdisabledにするようにした。
初回読み込み時は通信エラーで無いのかそもそもログが無いのか判別出来なかったので、
判別できるように調整。
ホバー時のアニメだったり更新ボタンもちょっと調整