### PR TITLE
投稿時刻と閲覧時刻を記録する

### DIFF
--- a/server/campBbsData/kyotu/master_params.json
+++ b/server/campBbsData/kyotu/master_params.json
@@ -1,10 +1,1 @@
-{
-    "eventNo": 18,
-    "islandTurn": 67,
-    "transitionableTime": 2556111599,
-    "camp": [
-        { "id": 1, "name": "魏", "mark": "∀" },
-        { "id": 2, "name": "呉", "mark": "Ψ" },
-        { "id": 3, "name": "蜀", "mark": "Ж" }
-    ]
-}
+{"islandTurn":67,"camp":[{"name":"魏","id":1,"mark":"∀","newestMessageTime":1739110772},{"name":"呉","id":2,"mark":"Ψ","newestMessageTime":2556111599},{"id":3,"name":"蜀","newestMessageTime":2556111599,"mark":"Ж"}],"transitionableTime":2556111599,"eventNo":18}

--- a/server/server_perl.cgi
+++ b/server/server_perl.cgi
@@ -10,6 +10,7 @@ use utf8;
     use JSON;
     use lib './lib';
     use File::Copy;
+    use File::Path;
     use File::Temp qw/ tempfile /;
     use CampBbs::Image::IntegrityValidator qw(validate_image_integrity);
 
@@ -47,7 +48,7 @@ use utf8;
 
             is_valid_camp_id_check($campNo, $hako_idx);
 
-            if (!(-d $campBbsData_FILEPATH)) {
+            if (!(-d "$campBbsData_FILEPATH/image")) {
                 # 初めてなのでディレクトリとファイルを作成
                 mkpath("$campBbsData_FILEPATH/image") or handleException_exit("Cannot create directory", $!);
                 write_file_with_lock("$campBbsData_FILEPATH/campBbsLog.json", encode_json({"$campNo"}), ">");


### PR DESCRIPTION
- メッセージを投稿した時にその陣営の掲示板の最終投稿時刻を記録する
(最終投稿メッセージの時刻をselectして取得するのが理想だが、現状のファイル管理じゃ無理なのでメッセージ削除されたら致し方なし)
- 掲示板閲覧時にその島の最終閲覧時刻を更新する。NEW表示だけなので更新出来ない場合は変わらず遷移させる。
- 必要なモジュールを消してしまっていたので修正